### PR TITLE
Make it so you can set a default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ The floating label for the paper-input.
 Indicates to the control that selection of a place is mandatory and that an empty input is not valid.
 ### hide-error
 If specified the element doesn't display an error message and doesn't turn red
+### search-value
+Use this to set a default search value
 ## Methods - Convenience Functions
 ### geocode(address)
 The `geocode` function takes an address as it's parameter and returns a _promise_ for a result which is a _place object_ as described in the place property above.  Note that this does not have any effect on the control's properties (but, of course one could turn around and set the value property with information from the place detail returned).

--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,5 @@
     "highlightjs": "^9.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,5 @@
     "highlightjs": "^9.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,5 @@
     "highlightjs": "^9.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
-  "version": "1.0.4"
+  "version": "1.0.5"
 }

--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,5 @@
     "highlightjs": "^9.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/paper-input-place.html
+++ b/paper-input-place.html
@@ -175,6 +175,9 @@ Google Places Autocomplete attached to paper-input
         this._geocoder = new google.maps.Geocoder();
         this._places = new google.maps.places.Autocomplete(this.$$('#locationsearch').inputElement, {});
         google.maps.event.addListener(this._places, 'place_changed', this._onChangePlace.bind(this));
+        if (this.searchValue != '') {
+          this._svalChanged(this.searchValue, '');
+        }
       },
 
       _valueChanged: function(newValue, oldValue) {

--- a/paper-input-place.html
+++ b/paper-input-place.html
@@ -20,7 +20,7 @@ Google Places Autocomplete attached to paper-input
     </style>
     <template is="dom-if" if="[[apiKey]]" restamp="true">
       <google-maps-api api-key="[[apiKey]]" on-api-load="_mapsApiLoaded"></google-maps-api>
-      <paper-input id="locationsearch" label="[[label]]" value="{{_value}}" invalid="[[invalid]]" disabled$="[[disabled]]" error-message="Invalid - please select a place">
+      <paper-input id="locationsearch" label="[[label]]" value="[[searchValue]]" invalid="[[invalid]]" disabled$="[[disabled]]" error-message="Invalid - please select a place">
         <iron-icon icon="clear" suffix on-tap="_clearLocation"></iron-icon>
       </paper-input>
     </template>
@@ -40,7 +40,7 @@ Google Places Autocomplete attached to paper-input
           notify: true
         },
         /**
-         * Wether to hide the error message
+         * Hide error messages
          */
         hideError: {
           type: Boolean,
@@ -152,11 +152,13 @@ Google Places Autocomplete attached to paper-input
           notify: true,
           observer: '_valueChanged'
         },
-        /** @private */
-        _value: {
+        /**
+         * Use this to set a default value
+         */
+        searchValue: {
           type: String,
           notify: true,
-          value: "",
+          value: '',
           observer: '_svalChanged'
         }
 
@@ -179,7 +181,7 @@ Google Places Autocomplete attached to paper-input
         // update the search term and the invalid flag if the value is being set for the first time,
         // or if the value has changed and is not the same as the search term
         if (!oldValue || (newValue.search !== oldValue.search || newValue.search !== this._value)) {
-          this._value = newValue && newValue.search ? newValue.search : "";
+          this.searchValue = newValue && newValue.search ? newValue.search : this.searchValue;
           this._invalid = !newValue || !(newValue.place_id && newValue.latLng && newValue.latLng.lat && newValue.latLng.lng);
           if (!this.hideError) {
             this._setInvalid(this.required ? this._invalid : this._invalid && (newValue && newValue.search));
@@ -258,7 +260,7 @@ Google Places Autocomplete attached to paper-input
       },
 
       _clearLocation: function(e) {
-        this._value = "";
+        this.searchValue = "";
       },
       /**
        * Geocodes an address
@@ -314,7 +316,7 @@ Google Places Autocomplete attached to paper-input
             lat: p.latLng.lat,
             lng: p.latLng.lng
           });
-          this._value = this.$$('paper-input').inputElement.value;
+          this.searchValue = this.$$('paper-input').inputElement.value;
           this.value = {
             search: this.$$('paper-input').inputElement.value,
             place_id: p.place_id,
@@ -420,7 +422,7 @@ Google Places Autocomplete attached to paper-input
               lng: newPlace.latLng.lng
             }
           };
-          this._value = newPlace.search;
+          this.searchValue = newPlace.search;
         }
       }
 


### PR DESCRIPTION
Make _value public and rename it to searchValue so you can set a default value by providing search-value="default value" to the paper-input-place element.

I use this in my own site because I use geoip to determine visitors city by ip and default that into the paper-input-place
