### PR TITLE
Fix issue #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Google Places Autocomplete attached to a paper-input, providing a convenient mat
 Basic use:
 
 ```html
-<paper-input-place api-key="your google api key" value="{{tourstop.place}}"></paper-input-place>
+<paper-input-place api-key="your google api key" value="{{tourstop.place}}" hide-error></paper-input-place>
 ```
 The `value` property is an object:
 
@@ -21,7 +21,28 @@ The `value` property is an object:
   }
 }
 ```
+Basic use with validation:
+
+```html
+<paper-input-place api-key="your google api key" value="{{tourstop.place}}"></paper-input-place>
+```
+## Installation
+
+Use bower to install:
+`bower install --save paper-input-place`
+
 ## Additional Properties
+### apiLoaded
+A _read only_ boolean property (notifies) that indicates if the google api is
+loaded and ready to provide place suggestions and geocoding services.
+
+The control also fires an event, `api-loaded`, when the google api is ready
+and attached to the input control.
+
+### hideError
+If specified the element doesn't display an error message and doesn't turn red.
+Set `hide-error` in the markup to suppress validation.
+
 ### invalid
 `invalid` is a _read only_ property which indicates if the control has a valid place.
 ```html
@@ -161,8 +182,7 @@ The floating label for the paper-input.
 ```
 ### required
 Indicates to the control that selection of a place is mandatory and that an empty input is not valid.
-### hide-error
-If specified the element doesn't display an error message and doesn't turn red
+
 ## Methods - Convenience Functions
 ### geocode(address)
 The `geocode` function takes an address as it's parameter and returns a _promise_ for a result which is a _place object_ as described in the place property above.  Note that this does not have any effect on the control's properties (but, of course one could turn around and set the value property with information from the place detail returned).
@@ -182,6 +202,19 @@ The `reverseGeocode` function takes a latLng object as it's parameter and return
 this.$$('paper-input-place').reverseGeocode(latlng).then(
   function(result) {
     // do something with result (a place object)
+  }.bind(this),
+  function(status) {
+    // do something with status - the reason the geocode did not work
+  }.bind(this)
+);
+```
+### putPlace(place)
+The `putPlace` function takes a place object and updates the control to reflect that place.
+```js
+this.$$('paper-input-place').geocode('Qualcomm Stadium').then(
+  function(result) {
+    // set the control to this place
+    this.$$('paper-input-place').putPlace(result);
   }.bind(this),
   function(status) {
     // do something with status - the reason the geocode did not work

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,9 @@
     "places",
     "autocomplete",
     "google-places",
-    "web-components"
+    "web-components",
+    "geocode",
+    "reverse-geocode"
   ],
   "license": "MIT",
   "dependencies": {
@@ -23,5 +25,5 @@
     "highlightjs": "^9.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
-  "version": "1.0.3"
+  "version": "1.1.0"
 }

--- a/paper-input-place.html
+++ b/paper-input-place.html
@@ -10,7 +10,7 @@ Google Places Autocomplete attached to paper-input
 
 @demo demo/index.html
 
-@version 1.0.3
+@version 1.1.0
 -->
 
 <dom-module id="paper-input-place">
@@ -22,10 +22,10 @@ Google Places Autocomplete attached to paper-input
     </style>
     <template is="dom-if" if="[[apiKey]]" restamp="true">
       <google-maps-api api-key="[[apiKey]]" on-api-load="_mapsApiLoaded"></google-maps-api>
-      <paper-input id="locationsearch" label="[[label]]" value="{{_value}}" invalid="[[invalid]]" disabled$="[[disabled]]" error-message="Invalid - please select a place">
-        <iron-icon icon="clear" suffix on-tap="_clearLocation"></iron-icon>
-      </paper-input>
     </template>
+  <paper-input id="locationsearch" label="[[label]]" value="{{_value}}" invalid="[[invalid]]" disabled$="[[disabled]]" error-message="Invalid - please select a place">
+    <iron-icon icon="clear" suffix on-tap="_clearLocation"></iron-icon>
+  </paper-input>
   </template>
 
   <script>
@@ -42,7 +42,18 @@ Google Places Autocomplete attached to paper-input
           notify: true
         },
         /**
-         * Wether to hide the error message
+         * Indicates the Google API is loaded and that Autocomplete suggestions and geocoding functions are available
+         */
+        apiLoaded: {
+          type: Boolean,
+          notify: true,
+          value: false,
+          readOnly: true
+        },
+        /**
+         * Whether to hide the error message
+         * If true, the control does not validate that the value is complete (lat/lng, search term, place_id)
+         * and has been chosen from the places drop down.
          */
         hideError: {
           type: Boolean,
@@ -172,9 +183,15 @@ Google Places Autocomplete attached to paper-input
       },
 
       _mapsApiLoaded: function() {
-        this._geocoder = new google.maps.Geocoder();
-        this._places = new google.maps.places.Autocomplete(this.$$('#locationsearch').inputElement, {});
-        google.maps.event.addListener(this._places, 'place_changed', this._onChangePlace.bind(this));
+        if (!this._geocoder && !this._places && this.$.locationsearch && this.$.locationsearch.inputElement) {
+          this._geocoder = new google.maps.Geocoder();
+          this._places = new google.maps.places.Autocomplete(this.$$('#locationsearch').inputElement, {});
+          google.maps.event.addListener(this._places, 'place_changed', this._onChangePlace.bind(this));
+          this._setApiLoaded(true);
+          this.fire('api-loaded', {
+            text: 'Google api is ready'
+          });
+        }
       },
 
       _valueChanged: function(newValue, oldValue) {
@@ -278,16 +295,20 @@ Google Places Autocomplete attached to paper-input
        */
       geocode: function(address, options) {
         return new Promise(function(resolve, reject) {
-          var opts = options ? options : {};
-          opts.address = address ? address : "";
-          this._geocoder.geocode(opts, function(results, status) {
-            if (status == google.maps.GeocoderStatus.OK && results && results[0]) {
-              var p = this._extractPlaceInfo(results[0], opts.address);
-              resolve(p);
-            } else {
-              reject(status);
-            }
-          }.bind(this));
+          if (!this._geocoder) {
+            reject('Geocoder not ready.');
+          } else {
+            var opts = options ? options : {};
+            opts.address = address ? address : "";
+            this._geocoder.geocode(opts, function(results, status) {
+              if (status == google.maps.GeocoderStatus.OK && results && results[0]) {
+                var p = this._extractPlaceInfo(results[0], opts.address);
+                resolve(p);
+              } else {
+                reject(status);
+              }
+            }.bind(this));
+          }
         }.bind(this));
       },
       /**
@@ -298,18 +319,22 @@ Google Places Autocomplete attached to paper-input
        */
       reverseGeocode: function(latlng, options) {
         return new Promise(function(resolve, reject) {
-          var opts = options ? options : {};
-          if (latlng) {
-            opts.location = latlng;
-          }
-          this._geocoder.geocode(opts, function(results, status) {
-            if (status == google.maps.GeocoderStatus.OK && results && results[0]) {
-              var p = this._extractPlaceInfo(results[0], "");
-              resolve(p);
-            } else {
-              reject(status);
+          if (!this._geocoder) {
+            reject('Geocoder not ready.');
+          } else {
+            var opts = options ? options : {};
+            if (latlng) {
+              opts.location = latlng;
             }
-          }.bind(this));
+            this._geocoder.geocode(opts, function(results, status) {
+              if (status == google.maps.GeocoderStatus.OK && results && results[0]) {
+                var p = this._extractPlaceInfo(results[0], "");
+                resolve(p);
+              } else {
+                reject(status);
+              }
+            }.bind(this));
+          }
         }.bind(this));
       },
 
@@ -435,5 +460,13 @@ Google Places Autocomplete attached to paper-input
       }
 
     });
+    /**
+    Fired when the google maps api has loaded.
+
+    The api is now available to provide
+    geocoding and place suggestions.
+
+    @event api-loaded
+    */
   </script>
 </dom-module>


### PR DESCRIPTION
Fixing [issue #8](https://github.com/mlisook/paper-input-place/issues/8) paper-input-place.html:176 Uncaught TypeError: Cannot read property 'inputElement' of null.

The error could occur in a couple of different ways. If the google maps api element loaded and received the api result (via ajax) before the paper-input control was attached, then an error resulted.  Alternatively, if the google maps api was loaded elsewhere on the page, perhaps in a google-map or in another copy of this control, the api could already be loaded even before this control is attached and again that would be before paper-input is attached.

This PR modifies the template so that paper-input is outside of the template dom-if api-key, which prevents the ready state from occurring before the paper-input is loaded.  It also implements a new test in _mapsApiLoaded to ensure the order of operations required and prevent the possible re initialization of the places autocomplete function.
