### PR TITLE
Fixed an issue with Polymer 2

### DIFF
--- a/paper-input-place.html
+++ b/paper-input-place.html
@@ -183,9 +183,9 @@ Google Places Autocomplete attached to paper-input
       },
 
       _mapsApiLoaded: function() {
-        if (!this._geocoder && !this._places && this.$.locationsearch && this.$.locationsearch.inputElement) {
+        if (!this._geocoder && !this._places && this.$.locationsearch && this.$.locationsearch.$.nativeInput) {
           this._geocoder = new google.maps.Geocoder();
-          this._places = new google.maps.places.Autocomplete(this.$$('#locationsearch').inputElement, {});
+          this._places = new google.maps.places.Autocomplete(this.$$('#locationsearch').$$('#nativeInput'), {});
           google.maps.event.addListener(this._places, 'place_changed', this._onChangePlace.bind(this));
           this._setApiLoaded(true);
           this.fire('api-loaded', {


### PR DESCRIPTION
The Maps Library raised an “InvalidValueError: not an instance of HTMLInputElement” error due to `<paper-input>` v2 instantiating an `<iron-input>` instead of an `<input>`