### PR TITLE
add error message property, improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ Google Places Autocomplete attached to a paper-input, providing a convenient mat
 
 This release is a Polymer 2.0 hybrid element so it will work in 1.x or 2.0 Polymer applications.
 
-[Live Demos](https://mlisook.github.io/paper-input-place/)
+Try it on the [Live Demos](https://mlisook.github.io/paper-input-place/) page.
 
-Basic use:
+## Contents
+* [Basic Use](#basic-use)
+* [Installation](#installation)
+* [Properties](#additional-properties)
+* [Methods](#methods)
+* [Styling](#styling)
+
+## Basic use
 
 ```html
 <paper-input-place api-key="your google api key" value="{{tourstop.place}}" 
@@ -41,6 +48,15 @@ loaded and ready to provide place suggestions and geocoding services.
 
 The control also fires an event, `api-loaded`, when the google api is ready
 and attached to the input control.
+
+### errorMessage
+`errorMessage` / `error-message` allows customization of the error message display.
+```html
+<paper-input-place api-key="your google api key" error-message="Pick a place from the list"
+  value="{{myPlace}}" required label="Select your destination"
+  invalid="{{noPlace}}"></paper-input-place>
+<paper-button disabled$="[[noPlace]]" on-tap="saveIt">Save</paper-button>
+```
 
 ### hideError
 If specified the element doesn't display an error message and doesn't turn red.
@@ -186,8 +202,8 @@ The floating label for the paper-input.
 ### required
 Indicates to the control that selection of a place is mandatory and that an empty input is not valid.
 
-## Methods - Convenience Functions
-While not needed for the main purpose, the user entering a place, you may have existing data you
+## Methods
+Convenience functions.  While not needed for the main purpose, the user entering a place, you may have existing data you
 need to geocode for use in the element.  We make these functions available here since the Google
 API is already loaded.
 
@@ -227,4 +243,44 @@ this.$$('paper-input-place').geocode('Qualcomm Stadium').then(
     // do something with status - the reason the geocode did not work
   }.bind(this)
 );
+```
+
+## Styling
+Style the `paper-input-place` element as you would a `paper-input` - use the mixins and variables
+of `paper-input-container` documented on the [paper-input-container api page](https://www.webcomponents.org/element/PolymerElements/paper-input/elements/paper-input-container). Apply the style to the `paper-input-place` element.
+
+Example: make the `paper-input-place` more green:
+
+```html
+<template>
+  <style>
+    paper-input-place {
+      width: 450px;
+    }
+    paper-input-place.make-it-green {        
+      --paper-input-container-underline: {
+        border-bottom: 2px dotted lightgreen;
+      }
+      --paper-input-container-underline-focus: {
+        border-bottom: 4px solid green;
+      }
+      --paper-input-container-label-focus: {
+        font-style: italic;
+        color: green;
+        font-weight: bold;
+      }
+      --paper-input-container-label: {
+        font-style: italic;
+        color: lightgreen;
+        font-weight: normal;
+      }
+        --paper-input-container-label-floating: {
+        font-style: italic;
+        color: darkgreen;
+        font-weight: bold;
+      }
+    }
+  </style>
+  <paper-input-place class="make-it-green" value="{{val}}" place="{{place}}" invalid="{{inv}}" api-key="[[apiKey]]" label="Pick a place, any place" hide-error></paper-input-place>
+</template>
 ```

--- a/bower.json
+++ b/bower.json
@@ -29,5 +29,5 @@
     "highlightjs": "^9.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
-  "version": "1.9.1"
+  "version": "1.9.2"
 }

--- a/paper-input-place.html
+++ b/paper-input-place.html
@@ -35,11 +35,12 @@ Basic use with validation:
 <paper-input-place label="Pick a place" api-key="your google api key" value="{{tourstop.place}}"></paper-input-place>
 ```
 
+See README.MD for more use examples, styling, api and a link to a live demo page.
 
 
 @demo demo/index.html
 
-@version 1.9.0
+@version 1.9.2
 -->
 
 <dom-module id="paper-input-place">
@@ -67,7 +68,7 @@ Basic use with validation:
         library-loaded="{{_ijplLoaded}}" 
         on-map-api-load="_mapsApiLoaded"></iron-jsonp-library>
     </template>
-  <paper-input id="locationsearch" label="[[label]]" value="{{_value}}" invalid="[[invalid]]" disabled$="[[disabled]]" error-message="Invalid - please select a place">
+  <paper-input id="locationsearch" label="[[label]]" value="{{_value}}" invalid="[[invalid]]" disabled$="[[disabled]]" error-message="[[errorMessage]]">
     <iron-icon icon="papinpplc:clear" suffix on-tap="_clearLocation"></iron-icon>
   </paper-input>
   </template>
@@ -114,6 +115,15 @@ Basic use with validation:
         /** @private */
         _geocoder: {
           type: Object
+        },
+        /**
+         * error message to display if place is invalid (and hideError is false).
+         * Default value is "Invalid - please select a place".
+         */
+        errorMessage: {
+          type: String,
+          value: "Invalid - please select a place",
+          notify: true
         },
         /**
          * True if the entered text is not valid - i.e. not a selected place and not previously geocoded


### PR DESCRIPTION
This addresses [issue 17 Add errorMessage property](https://github.com/mlisook/paper-input-place/issues/17) by adding an `errorMessage` / `error-message` property.

This addresses [issue 16 how to define css rules](https://github.com/mlisook/paper-input-place/issues/16) by adding a section to the README.md file with an example of styling the element.
